### PR TITLE
更新iOS端设备指纹适配苹果隐私政策接入方式

### DIFF
--- a/设备指纹/iOS/设备指纹_iOS_接入手册.md
+++ b/设备指纹/iOS/设备指纹_iOS_接入手册.md
@@ -5,7 +5,7 @@
 ### 1.1 导入 smsdk 包
 
 - 旧版 smsdk 使用 .a 形式的包，导入方式如下：
-     
+  
      在项目中选择 Add Files to，在弹出的界面中选择 Copy items if needed，再选择 SmAntiFraud.h 和 libSmAntiFraud.a，选择添加。
      
      ![image-20220907172509726](./res/image-20220907172509726.png)
@@ -50,6 +50,15 @@ smsdk 默认使用 http 请求，根据苹果的 ATS 标准，需要配置 Info.
    若不想使用 `IDFA`，可参考下面初始化章节，设置 `notCollect` 不采集 `IDFA`，
 
    若app归属于儿童类，则联系数美运营提供不包含采集 `IDFA` 相关代码的SDK。
+
+### 1.5 配置隐私文件
+
+根据[苹果隐私政策规定](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files?language=objc)，嵌入数美SDK的app需要在Xcode项目的 PrivacyInfo.xcprivacy 中补全条款，若项目中没有，需要根据[官方说明](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files?language=objc)使用Xcode 15及以上的版本新建一个 PrivacyInfo.xcprivacy 文件。
+
+开发者需要将数美SDK下的 PrivacyInfo.xcprivacy 中的条款补全到app的 PrivacyInfo.xcprivacy 中。
+
+数美SDK的 PrivacyInfo.xcprivacy 文件位于：
+SmAntiFraud.xcframework/ios-arm64/SmAntiFraud.framework/PrivacyInfo.xcprivacy
 
 
 


### PR DESCRIPTION
苹果隐私协议政策需要app添加PrivacyInfo.xcprivacy，并补充采集的数据
在接入文档中说明